### PR TITLE
Fix #37 initial setup for sciadro project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ web/.classpath
 web/.project
 backend/.classpath
 backend/.project
+package-lock.json

--- a/assets/themes/sciadro.less
+++ b/assets/themes/sciadro.less
@@ -1,0 +1,1 @@
+/* custom theme for sciadro branch */

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
             <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
         </div>
-        <script src="dist/MapStore2-C098.js"></script>
+        <script src="dist/sciadro.js"></script>
 
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
         <link rel="stylesheet" href="https://cesiumjs.org/releases/1.17/Build/Cesium/Widgets/widgets.css" />
         <script src="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.js"></script>
         <link rel="stylesheet" href="MapStore2/web/client/libs/cesium-navigation/cesium-navigation.css" />
+        <link rel="stylesheet" href="dist/themes-sciadro.css" />
 
     </head>
     <body>

--- a/js/appConfigSciadro.js
+++ b/js/appConfigSciadro.js
@@ -1,10 +1,10 @@
-/**
- * Copyright 2016, GeoSolutions Sas.
+/*
+ * Copyright 2019, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
 
 module.exports = {
     pages: [{
@@ -22,7 +22,7 @@ module.exports = {
             mousePosition: {enabled: false, "crs": "EPSG:4326"},
             controls: {
                 sciadro: {
-                    enabled: false
+                    enabled: true
                 }
             },
             maps: {

--- a/js/appConfigSciadro.js
+++ b/js/appConfigSciadro.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+    pages: [{
+        name: "home",
+        path: "/",
+        component: require('./pages/Sciadro')
+    }, {
+        name: "sciadro",
+        path: "/sciadro",
+        component: require('./pages/Sciadro')
+    }],
+    initialState: {
+        defaultState: {
+            mapInfo: {enabled: true, infoFormat: 'text/html'},
+            mousePosition: {enabled: false, "crs": "EPSG:4326"},
+            controls: {
+                sciadro: {
+                    enabled: false
+                }
+            },
+            maps: {
+                mapType: "openlayers"
+            },
+            maptype: {
+                mapType: "openlayers"
+            }
+        },
+        mobile: {
+            mapInfo: {enabled: true, infoFormat: 'application/json' },
+            mousePosition: {enabled: true, crs: "EPSG:4326", showCenter: true}
+        }
+    },
+    appEpics: {},
+    storeOpts: {
+        persist: {
+            whitelist: ['security']
+        }
+    }
+};

--- a/js/components/Container.jsx
+++ b/js/components/Container.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import DockablePanel from '../../MapStore2/web/client/components/misc/panels/DockablePanel';
+import Message from '../../MapStore2/web/client/components/I18N/Message';
+
+/**
+ * Main Container for sciadro app
+ * @class
+ * @memberof components.Container
+ * @prop {boolean} show the panel
+
+ */
+class Container extends React.Component {
+    static propTypes = {
+        show: PropTypes.bool
+    };
+
+    static defaultProps = {
+        show: true
+    };
+
+    render() {
+
+        return (<DockablePanel
+            dock
+            bsStyle="primary"
+            position="left"
+            title={<Message key="title" msgId="sciadro.title"/>}
+            glyph="1-ruler"
+            size={660}
+            open={this.props.show}>
+                Main panel component
+            </DockablePanel>);
+
+    }
+}
+
+export default Container;

--- a/js/components/Container.jsx
+++ b/js/components/Container.jsx
@@ -4,7 +4,7 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
 
 
 import React from 'react';
@@ -17,28 +17,44 @@ import Message from '../../MapStore2/web/client/components/I18N/Message';
  * @class
  * @memberof components.Container
  * @prop {boolean} show the panel
-
- */
+*/
 class Container extends React.Component {
     static propTypes = {
-        show: PropTypes.bool
+        bsStyle: PropTypes.string,
+        dock: PropTypes.bool,
+        glyph: PropTypes.string,
+        position: PropTypes.string,
+        title: PropTypes.string,
+        show: PropTypes.bool,
+        size: PropTypes.number
     };
-
+    static contextTypes = {
+        messages: PropTypes.object
+    };
     static defaultProps = {
-        show: true
+        bsStyle: "primary",
+        dock: true,
+        glyph: "globe",
+        position: "left",
+        title: "sciadro.titlePanel",
+        show: true,
+        size: 660
     };
 
     render() {
 
         return (<DockablePanel
-            dock
-            bsStyle="primary"
-            position="left"
-            title={<Message key="title" msgId="sciadro.title"/>}
-            glyph="1-ruler"
-            size={660}
+            dock={this.props.dock}
+            bsStyle={this.props.bsStyle}
+            position={this.props.position}
+            title={<Message key="title" msgId={this.props.title}/>}
+            glyph={this.props.glyph}
+            size={this.props.size}
             open={this.props.show}>
-                Main panel component
+                <p>
+                    <h2>ASSET</h2>
+                </p>
+
             </DockablePanel>);
 
     }

--- a/js/components/__tests__/Container-test.js
+++ b/js/components/__tests__/Container-test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from "expect";
+import React from "react";
+import ReactDOM from "react-dom";
+import Container from "../Container";
+
+
+describe('testing Container for sciadro plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById("container"));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('rendering Container with defaults', () => {
+        const container = ReactDOM.render(<Container />, document.getElementById("container"));
+        expect(container).toExist();
+    });
+});

--- a/js/pages/Sciadro.jsx
+++ b/js/pages/Sciadro.jsx
@@ -4,12 +4,12 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
-const React = require('react');
-const PropTypes = require('prop-types');
-const {connect} = require('react-redux');
-const Page = require('../../MapStore2/web/client/containers/Page');
-const {loadMapConfig} = require('../../MapStore2/web/client/actions/config');
+*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import Page from '../../MapStore2/web/client/containers/Page';
+import {loadMapConfig} from '../../MapStore2/web/client/actions/config';
 
 
 class SciadroPage extends React.Component {
@@ -39,7 +39,7 @@ class SciadroPage extends React.Component {
     render() {
         let plugins = this.props.pluginsConfig;
         let pluginsConfig = {
-            "desktop": plugins[this.props.name] || [], // TODO mesh page plugins with other plugins
+            "desktop": plugins[this.props.name] || [],
             "mobile": plugins[this.props.name] || []
         };
 

--- a/js/pages/Sciadro.jsx
+++ b/js/pages/Sciadro.jsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const React = require('react');
+const PropTypes = require('prop-types');
+const {connect} = require('react-redux');
+const Page = require('../../MapStore2/web/client/containers/Page');
+const {loadMapConfig} = require('../../MapStore2/web/client/actions/config');
+
+
+class SciadroPage extends React.Component {
+    static propTypes = {
+        name: PropTypes.string,
+        mode: PropTypes.string,
+        geoStoreUrl: PropTypes.string,
+        loadMapConfig: PropTypes.func,
+        match: PropTypes.object,
+        plugins: PropTypes.object,
+        pluginsConfig: PropTypes.object
+    }
+    static contextTypes = {
+        router: PropTypes.object
+    }
+    static defaultProps = {
+        name: "sciadro",
+        mode: 'desktop',
+        match: {},
+        reset: () => {},
+        pluginsConfig: {}
+    }
+    componentWillMount() {
+        this.props.loadMapConfig("config.json", null);
+    }
+
+    render() {
+        let plugins = this.props.pluginsConfig;
+        let pluginsConfig = {
+            "desktop": plugins[this.props.name] || [], // TODO mesh page plugins with other plugins
+            "mobile": plugins[this.props.name] || []
+        };
+
+        return (<Page
+            id="sciadro"
+            pluginsConfig={pluginsConfig}
+            plugins={this.props.plugins}
+            params={this.props.match.params}
+            />);
+    }
+}
+
+module.exports = connect((state) => {
+    return {
+        mode: 'desktop',
+        geoStoreUrl: (state.localConfig && state.localConfig.geoStoreUrl) || null,
+        pluginsConfig: (state.localConfig && state.localConfig.plugins) || null
+    };
+}, {
+    loadMapConfig
+})(SciadroPage);

--- a/js/plugins/Sciadro.jsx
+++ b/js/plugins/Sciadro.jsx
@@ -4,10 +4,10 @@
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
 
-import { connect } from '../../MapStore2/web/client/utils/PluginsUtils';
 import assign from 'object-assign';
+import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import Container from '../components/Container';
@@ -27,7 +27,7 @@ const Sciadro = connect(createSelector([
     // action: ActionCreator
 })(Container);
 
-export const SciadroPlugin = assign({}, Sciadro);
+export const SciadroPlugin = assign(Sciadro);
 
 /*
 export const reducers = { controls };

--- a/js/plugins/Sciadro.jsx
+++ b/js/plugins/Sciadro.jsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { connect } from '../../MapStore2/web/client/utils/PluginsUtils';
+import assign from 'object-assign';
+import { createSelector } from 'reselect';
+
+import Container from '../components/Container';
+
+/**
+ * Sciadro plugins allows to manage Assets and Missions
+ * @class
+ * @memberof plugins
+ * @prop {boolean} [show] show the opened main panel default true
+*/
+
+const Sciadro = connect(createSelector([
+    state => state.controls && state.controls.sciadro && state.controls.sciadro.enabled
+], (show) => ({
+    show
+})), {
+    // action: ActionCreator
+})(Container);
+
+export const SciadroPlugin = assign({}, Sciadro);
+
+/*
+export const reducers = { controls };
+export const epics = shareEpics;
+*/

--- a/js/pluginsSciadro.js
+++ b/js/pluginsSciadro.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+    plugins: {
+        MapPlugin: require('../MapStore2/web/client/plugins/Map'),
+        ToolbarPlugin: require('../MapStore2/web/client/plugins/Toolbar'),
+        ZoomInPlugin: require('../MapStore2/web/client/plugins/ZoomIn'),
+        ZoomOutPlugin: require('../MapStore2/web/client/plugins/ZoomOut'),
+        MapLoadingPlugin: require('../MapStore2/web/client/plugins/MapLoading'),
+        LoginPlugin: require('../MapStore2/web/client/plugins/Login'),
+        OmniBarPlugin: require('../MapStore2/web/client/plugins/OmniBar'),
+        NotificationsPlugin: require('../MapStore2/web/client/plugins/Notifications'),
+        SciadroPlugin: require('./plugins/Sciadro')
+    },
+    requires: {
+        ReactSwipe: require('react-swipeable-views').default,
+        SwipeHeader: require('../MapStore2/web/client/components/data/identify/SwipeHeader')
+    }
+};

--- a/js/pluginsSciadro.js
+++ b/js/pluginsSciadro.js
@@ -1,25 +1,26 @@
-/**
- * Copyright 2016, GeoSolutions Sas.
+/*
+ * Copyright 2019, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
- */
+*/
+
+import * as Map from '../MapStore2/web/client/plugins/Map';
+import * as Toolbar from '../MapStore2/web/client/plugins/Toolbar';
+import * as Login from '../MapStore2/web/client/plugins/Login';
+import * as OmniBar from '../MapStore2/web/client/plugins/OmniBar';
+import * as Notifications from '../MapStore2/web/client/plugins/Notifications';
+import * as Sciadro from './plugins/Sciadro';
 
 module.exports = {
     plugins: {
-        MapPlugin: require('../MapStore2/web/client/plugins/Map'),
-        ToolbarPlugin: require('../MapStore2/web/client/plugins/Toolbar'),
-        ZoomInPlugin: require('../MapStore2/web/client/plugins/ZoomIn'),
-        ZoomOutPlugin: require('../MapStore2/web/client/plugins/ZoomOut'),
-        MapLoadingPlugin: require('../MapStore2/web/client/plugins/MapLoading'),
-        LoginPlugin: require('../MapStore2/web/client/plugins/Login'),
-        OmniBarPlugin: require('../MapStore2/web/client/plugins/OmniBar'),
-        NotificationsPlugin: require('../MapStore2/web/client/plugins/Notifications'),
-        SciadroPlugin: require('./plugins/Sciadro')
+        MapPlugin: Map,
+        ToolbarPlugin: Toolbar,
+        LoginPlugin: Login,
+        OmniBarPlugin: OmniBar,
+        NotificationsPlugin: Notifications,
+        SciadroPlugin: Sciadro
     },
-    requires: {
-        ReactSwipe: require('react-swipeable-views').default,
-        SwipeHeader: require('../MapStore2/web/client/components/data/identify/SwipeHeader')
-    }
+    requires: {}
 };

--- a/js/sciadro.jsx
+++ b/js/sciadro.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const ConfigUtils = require('../MapStore2/web/client/utils/ConfigUtils');
+/**
+ * Add custom (overriding) translations with:
+ *
+ * ConfigUtils.setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
+ */
+ConfigUtils.setConfigProp('translationsPath', './MapStore2/web/client/translations');
+ConfigUtils.setConfigProp('themePrefix', 'MapStore2-C098');
+
+/**
+ * Use a custom plugins configuration file with:
+ * ConfigUtils.setLocalConfigurationFile('MapStore2/web/client/localConfig.json');
+ *
+ */
+
+ConfigUtils.setLocalConfigurationFile('localConfig.json');
+
+/**
+ * Use a custom application configuration file with:
+ *
+ * const appConfig = require('./appConfig');
+ *
+ * Or override the application configuration file with (e.g. only one page with a mapviewer):
+ *
+ * const appConfig = assign({}, require('../MapStore2/web/client/product/appConfig'), {
+ *     pages: [{
+ *         name: "mapviewer",
+ *         path: "/",
+ *         component: require('../MapStore2/web/client/product/pages/MapViewer')
+ *     }]
+ * });
+ */
+const appConfig = require('./appConfigSciadro');
+
+/**
+ * Define a custom list of plugins with:
+ *
+ * const plugins = require('./plugins');
+ */
+const plugins = require('./pluginsSciadro');
+
+require('../MapStore2/web/client/product/main')(appConfig, plugins);

--- a/js/sciadro.jsx
+++ b/js/sciadro.jsx
@@ -1,50 +1,33 @@
 /*
- * Copyright 2016, GeoSolutions Sas.
+ * Copyright 2019, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-const ConfigUtils = require('../MapStore2/web/client/utils/ConfigUtils');
+import ConfigUtils from '../MapStore2/web/client/utils/ConfigUtils';
 /**
  * Add custom (overriding) translations with:
- *
- * ConfigUtils.setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
  */
-ConfigUtils.setConfigProp('translationsPath', './MapStore2/web/client/translations');
+ConfigUtils.setConfigProp('translationsPath', ['./MapStore2/web/client/translations', './translations']);
 ConfigUtils.setConfigProp('themePrefix', 'MapStore2-C098');
 
 /**
  * Use a custom plugins configuration file with:
- * ConfigUtils.setLocalConfigurationFile('MapStore2/web/client/localConfig.json');
  *
  */
-
 ConfigUtils.setLocalConfigurationFile('localConfig.json');
 
 /**
  * Use a custom application configuration file with:
- *
- * const appConfig = require('./appConfig');
- *
- * Or override the application configuration file with (e.g. only one page with a mapviewer):
- *
- * const appConfig = assign({}, require('../MapStore2/web/client/product/appConfig'), {
- *     pages: [{
- *         name: "mapviewer",
- *         path: "/",
- *         component: require('../MapStore2/web/client/product/pages/MapViewer')
- *     }]
- * });
  */
-const appConfig = require('./appConfigSciadro');
+import appConfig from './appConfigSciadro';
 
 /**
  * Define a custom list of plugins with:
- *
- * const plugins = require('./plugins');
  */
-const plugins = require('./pluginsSciadro');
+import plugins from './pluginsSciadro';
 
-require('../MapStore2/web/client/product/main')(appConfig, plugins);
+import main from '../MapStore2/web/client/product/main';
+main(appConfig, plugins);

--- a/localConfig.json
+++ b/localConfig.json
@@ -540,6 +540,44 @@
 				}
 			}
 		],
-		"manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"]
+		"manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"],
+		"sciadro": [
+			"Notifications",
+			{
+				"name": "Map",
+				"cfg": {
+					"mapOptions": {
+						"openlayers": {
+							"interactions": {
+								"pinchRotate": false,
+								"altShiftDragRotate": false
+							},
+							"attribution": {
+								"container": "#mapstore-map-footer-container"
+							}
+						},
+						"leaflet": {
+							"attribution": {
+								"container": "#mapstore-map-footer-container"
+							}
+						}
+					},
+					"toolsOptions": {
+						"scalebar": {
+							"container": "#mapstore-map-footer-container"
+						}
+					}
+				}
+			},
+ 			{
+				"name": "MapLoading",
+				"override": {
+					"Toolbar": {
+						"alwaysVisible": true
+					}
+				}
+			},
+      "OmniBar", "Login"
+		]
 	}
 }

--- a/localConfig.json
+++ b/localConfig.json
@@ -11,7 +11,7 @@
 	"ignoreMobileCss": false,
 	"useAuthenticationRules": true,
 	"loadAfterTheme": true,
-	"translationsPath": "./MapStore2/web/client/translations",
+	"translationsPath": ["./MapStore2/web/client/translations", "./translations"],
 	"themePrefix": "MapStore2-C098",
 	"defaultMapOptions": {
 		"cesium": {
@@ -542,7 +542,6 @@
 		],
 		"manager": ["Header", "Redirect", "Manager", "Home", "UserManager", "GroupManager", "Footer"],
 		"sciadro": [
-			"Notifications",
 			{
 				"name": "Map",
 				"cfg": {
@@ -569,15 +568,7 @@
 					}
 				}
 			},
- 			{
-				"name": "MapLoading",
-				"override": {
-					"Toolbar": {
-						"alwaysVisible": true
-					}
-				}
-			},
-      "OmniBar", "Login"
+      "Notifications", "OmniBar", "Login", "Sciadro"
 		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "main": "index.js",
     "devDependencies": {
         "acorn-jsx": "https://github.com/geosolutions-it/acorn-jsx/tarball/master",
+        "axios-mock-adapter": "1.16.0",
         "babel-core": "6.8.0",
         "babel-eslint": "4.1.8",
         "babel-istanbul-loader": "0.1.0",

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -15,7 +15,9 @@ module.exports = require('./MapStore2/buildConfig')(
     {
         'MapStore2-C098': path.join(__dirname, "js", "app"),
         'MapStore2-C098-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
-        'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api")
+        'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
+        'sciadro': path.join(__dirname, "js", "sciadro"),
+        'themes-sciadro': path.join(__dirname, "assets", "themes", "sciadro.less") // custom theme for sciadro
     },
     themeEntries,
     paths,

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -1,8 +1,22 @@
 {
     "locale": "en-US",
     "messages": {
-        "sciadro": {
-            "titlePanel": "Sciadro"
+    "sciadro": {
+        "titlePanel": "Sciadro",
+        "assets": {
+            "mode": {
+                "list": "Assets",
+                "detail": "Asset",
+                "edit": "Asset"
+            }
+        },
+        "missions": {
+            "mode": {
+                "list": "Missions",
+                "detail": "Mission",
+                "edit": "Mission"
+            }
         }
+    }
     }
 }

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -1,0 +1,8 @@
+{
+    "locale": "en-US",
+    "messages": {
+        "sciadro": {
+            "titlePanel": "Sciadro"
+        }
+    }
+}

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -5,16 +5,16 @@
             "titlePanel": "Sciadro",
             "assets": {
                 "mode": {
-                    "list": "Assets",
-                    "detail": "Asset",
-                    "edit": "Asset"
+                    "list": "Attività",
+                    "detail": "Attività",
+                    "edit": "Attività"
                 }
             },
             "missions": {
                 "mode": {
-                    "list": "Missions",
-                    "detail": "Mission",
-                    "edit": "Mission"
+                    "list": "Missioni",
+                    "detail": "Missione",
+                    "edit": "Missione"
                 }
             }
         }

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -1,0 +1,22 @@
+{
+    "locale": "it-IT",
+    "messages": {
+        "sciadro": {
+            "titlePanel": "Sciadro",
+            "assets": {
+                "mode": {
+                    "list": "Assets",
+                    "detail": "Asset",
+                    "edit": "Asset"
+                }
+            },
+            "missions": {
+                "mode": {
+                    "list": "Missions",
+                    "detail": "Mission",
+                    "edit": "Mission"
+                }
+            }
+        }
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ const config = require('./MapStore2/buildConfig')(
         'MapStore2-C098': path.join(__dirname, "js", "app"),
         'MapStore2-C098-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
         'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
-        'sciadro': path.join(__dirname, "js", "sciadro")
+        'sciadro': path.join(__dirname, "js", "sciadro"),
+        'themes-sciadro': path.join(__dirname, "assets", "themes", "sciadro.less")
     },
     themeEntries,
     {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const config = require('./MapStore2/buildConfig')(
         'MapStore2-C098-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
         'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
         'sciadro': path.join(__dirname, "js", "sciadro"),
-        'themes-sciadro': path.join(__dirname, "assets", "themes", "sciadro.less")
+        'themes-sciadro': path.join(__dirname, "assets", "themes", "sciadro.less") // custom theme for sciadro
     },
     themeEntries,
     {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,11 +3,12 @@ const path = require("path");
 const themeEntries = require('./MapStore2/themes.js').themeEntries;
 const extractThemesPlugin = require('./MapStore2/themes.js').extractThemesPlugin;
 
-module.exports = require('./MapStore2/buildConfig')(
+const config = require('./MapStore2/buildConfig')(
     {
         'MapStore2-C098': path.join(__dirname, "js", "app"),
         'MapStore2-C098-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
-        'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api")
+        'MapStore2-C098-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api"),
+        'sciadro': path.join(__dirname, "js", "sciadro")
     },
     themeEntries,
     {
@@ -21,3 +22,13 @@ module.exports = require('./MapStore2/buildConfig')(
     "/dist/",
     '.MapStore2-C098'
 );
+config.devServer.proxy = {
+    '/rest/geostore': {
+        target: "http://localhost:8040/mapstore"
+    },
+    '/proxy': {
+        target: "http://localhost:8040/mapstore"
+    }
+};
+
+module.exports = config;


### PR DESCRIPTION
Fix #37 

configured:
- local translations
- a minimal list of plugins (plugins.js and localconfig)
- local theme in assets/themes/sciadro.less
- SciadroPlugin with a dockable panel
- sciadro page
- index.html to load sciadro js and css
- a test for main container 